### PR TITLE
Update gatsby-remark-autolink-headers import nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ module.exports = ({ root }) => ({
               fromHeading: 1,
               toHeading: 6
             },
-            `gatsby-remark-autolink-headers`
-          }
+          },
+          `gatsby-remark-autolink-headers`
         ],
       },
     },


### PR DESCRIPTION
Hi,

Is there a reason why `gatsby-remark-autolink-headers` is nested inside `gatsby-remark-table-of-contents` in the README?

For reference, this is how I configured table-of-contents in my `gatsby-config`.

```javascript
{
    resolve: `gatsby-remark-table-of-contents`,
    options: {
      exclude: 'Table of Contents',
      tight: false,
      fromHeading: 2,
      toHeading: 3,
    },
},
{
    resolve: 'gatsby-remark-autolink-headers',
    options: {
      elements: [`h1`, `h2`, `h3`],
    },
},
```

Also, thanks a bunch for this neat plugin. Saved me some time implementing it myself, and worked straight out-of-the-box! 🌟 