### PR TITLE
Update rollup.config.js to be compatible with Gatsby v4

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ export default [
     input: "src/index.js",
     external: [],
     output: [
-      { file: pkg.main, format: "cjs", exports: "named" },
+      { file: pkg.main, format: "cjs", exports: "default" },
       { file: pkg.module, format: "es" },
     ],
   },


### PR DESCRIPTION
This PR sets up a fix for https://github.com/signalwerk/gatsby-remark-table-of-contents/issues/28

Alter `output.exports` in the rollup config to be `default` for cjs output. 

I have tested this fix when using the `gatsby-remark-table-of-contents` plugin with both `gatsby-plugin-mdx` and `gatsby-transformer-remark` and this new config works with both.